### PR TITLE
Turn off autocapitalization on the answer input.

### DIFF
--- a/bbo.html
+++ b/bbo.html
@@ -280,7 +280,7 @@
     <div id="result" class="right">X</div>
     <div id="question"></div>
     <div id="whattoput"></div>
-    <input type="text" name="answer" id="answer" required size="20" placeholder="">
+    <input type="text" name="answer" id="answer" required size="20" placeholder="" autocapitalize="none">
     <div id="solution"></div>
   </div>
 


### PR DESCRIPTION
Mobile keyboards default to autocapitalization. Uppercase characters then get converted to Katakana on reading answers, which causes the answer to be flagged wrong. 

Example: You enter "Omou", you expect "おもう", but you get "オもう" because the first charater is uppercase.